### PR TITLE
[Breaking] Consistency Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Baselines Bots
 
+[x] means it has been updated to Karthik's new style
+
 This is a collection of simple baseline bots
 
 The bot parent-child relationships are as follow:
@@ -10,7 +12,7 @@ The bot parent-child relationships are as follow:
 
     * pushover_bot - executes whatever orders the last message told it to (Joy #5)
 
-    * random_proposer_bot - randomly proposes moves to other bots
+    * random_proposer_bot - randomly proposes moves to other bots [x]
 
         * random_allier_proposer_bot - first sends alliance proposals then randomly proposes moves to other bots
 

--- a/baseline_bot.py
+++ b/baseline_bot.py
@@ -53,11 +53,11 @@ class BaselineBot(ABC):
             return False
 
     @abstractmethod
-    def comms(self, rcvd_messages):
+    def gen_messages(self, rcvd_messages):
         """sets messages to be sent"""
         raise NotImplementedError()
 
     @abstractmethod
-    def act(self) -> None:
+    def gen_orders(self) -> None:
         """finalizes moves"""
         raise NotImplementedError()

--- a/daide_utils.py
+++ b/daide_utils.py
@@ -172,7 +172,7 @@ class BotReturnData:
                 self.orders.append(order)
                 self.orders_start_locs.add(order_tokens[0])
 
-class CommsData:
+class MessagesData:
     def __init__(self):
         self.messages = []
 
@@ -202,6 +202,7 @@ class OrdersData:
                     print(f"Not adding {order} since one with this start location is already added")
             except IndexError:
                 self.orders[order_tokens[0]] = order
+
     def update_orders(self, orders):
         for order in orders:
             try:

--- a/random_proposer_bot.py
+++ b/random_proposer_bot.py
@@ -14,8 +14,8 @@ class RandomProposerBot(BaselineBot):
 
     def __init__(self, power_name, game) -> None:
         super().__init__(power_name, game)
-
-    def act(self):
+    
+    def gen_messages(self, _) -> BotReturnData:
         # Return data initialization
         ret_obj = BotReturnData()
 
@@ -31,6 +31,9 @@ class RandomProposerBot(BaselineBot):
             ret_obj.add_message(other_power, str(suggested_random_orders))
 
         return ret_obj
+
+    def gen_orders(self):
+        return None
         
 if __name__ == "__main__":
     from diplomacy import Game
@@ -42,21 +45,15 @@ if __name__ == "__main__":
     # instantiate random honest bot
     bot = RandomProposerBot(bot_power, game)
     while not game.is_game_done:
-        bot_state = bot.act()
-        messages, orders = bot_state.messages, bot_state.orders
-        if messages:
-            # print(power_name, messages)
-            for msg in messages:
-                msg_obj = Message(
-                    sender=bot.power_name,
-                    recipient=msg['recipient'],
-                    message=msg['message'],
-                    phase=game.get_current_phase(),
-                )
-                game.add_message(message=msg_obj)
-        # print("Submitted orders")
-        if orders is not None:
-            game.set_orders(power_name=bot.power_name, orders=orders)
+        messages = bot.gen_messages(None).messages
+        for msg in messages:
+            msg_obj = Message(
+                sender=bot.power_name,
+                recipient=msg['recipient'],
+                message=msg['message'],
+                phase=game.get_current_phase(),
+            )
+            game.add_message(message=msg_obj)
 
         game.process()
 


### PR DESCRIPTION
- renamed `act()` to `gen_orders()` and `comms()` to `gen_messages()` @kartik2112 
- Start using `Messages` or `Msgs` in class/function names rather than `Comms`.
   - This is consistent with [Diplomacy](https://github.com/diplomacy/diplomacy)
- Started list of bots converted to new format in README (I may move this to an issue)