### PR TITLE
fix: messaging functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ git+https://github.com/trigaten/DAIDE.git
 karma-sphinx-theme
 black
 isort
-git+https://github.com/SHADE-AI/daidepp.git
 git+https://github.com/ALLAN-DIP/stance_vector.git
 numpy

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -5,10 +5,8 @@ from DAIDE import FCT, XDO, ORR
 from diplomacy import Message
 
 from baseline_bots.bots.random_proposer_bot import RandomProposerBot
-from baseline_bots.utils import MessagesData, OrdersData, get_other_powers, get_best_orders
+from baseline_bots.utils import MessagesData, OrdersData, get_other_powers, get_best_orders, parse_PRP, parse_orr_xdo
 from typing import List, Dict, Tuple
-
-from daidepp import create_daide_grammar, daide_visitor
 
 from stance_vector import ScoreBasedStance
 
@@ -33,21 +31,14 @@ class SmartOrderAccepterBot(RandomProposerBot):
     def get_proposals(self, rcvd_messages: List[Tuple[int, Message]]) -> Dict[str, str]:
         """
         Extract proposal messages from received messages and checks for valid syntax before returning it
-        """
-        grammar = create_daide_grammar(level=130)
-        
+        """        
         # Extract messages containing PRP string
         order_msgs = [msg[1] for msg in rcvd_messages if "PRP" in msg[1].message]
 
         proposals = {}
         for order_msg in order_msgs:
             try:
-                # Parse using DAIDEPP functions
-                parse_tree = grammar.parse(order_msg.message)
-                output = daide_visitor.visit(parse_tree)
-
-                if output[0] == 'PRP':
-                    proposals[order_msg.sender] = order_msg.message
+                proposals[order_msg.sender] = parse_PRP(parse_orr_xdo(order_msg.message))
             except Exception as e:
                 print(e)
                 pass

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -28,7 +28,7 @@ class SmartOrderAccepterBot(RandomProposerBot):
         self.alliance_props_sent = False
         self.stance = ScoreBasedStance(power_name, game)
 
-    def get_proposals(self, rcvd_messages: List[Tuple[int, Message]]) -> Dict[str, str]:
+    def get_proposals(self, rcvd_messages: List[Tuple[int, Message]]) -> Dict[str, List[str]]:
         """
         Extract proposal messages from received messages and checks for valid syntax before returning it
         """        

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -104,7 +104,16 @@ def parse_FCT(msg) -> str:
     try:
         return msg[5:-1]
     except Exception:
-        raise ParseError(f"Cant parse ORR XDO msg {msg}")
+        raise ParseError(f"Cant parse FCT msg {msg}")
+
+def parse_PRP(msg) -> str:
+    """Detaches PRP from main arrangement"""
+    if "PRP" not in msg:
+        raise ParseError("This is not an PRP message")
+    try:
+        return msg[5:-1]
+    except Exception:
+        raise ParseError(f"Cant parse PRP msg {msg}")
 
 
 def parse_orr_xdo(msg: str) -> List[str]:


### PR DESCRIPTION
Rolled back to using baseline_bots/utils functions instead of relying on DAIDE++ functions since there is some discrepancy between the expected syntax for DAIDE++

Updated get_proposals output type to match downstream `get_best_orders` function parameters