### PR TITLE
Fix ally move filter and get best order

### DIFF
--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -125,8 +125,8 @@ class SmartOrderAccepterBot(DipnetBot):
         elif self.stance_type == "S":
             self.stance = ScoreBasedStance(power_name, game)
         self.alliances = defaultdict(list)
-        self.rollout_length = 5
-        self.rollout_n_order = 5
+        self.rollout_length = 1
+        self.rollout_n_order = 10
         self.allies_influence = set()
         self.orders = None
         self.my_influence = set()

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -596,10 +596,8 @@ class SmartOrderAccepterBot(DipnetBot):
 
         # if none in dipnet beam orders
         for current_order in self.orders.get_list_of_orders():
-            if (
-                current_order != order
-                and not self.is_order_aggressive_to_powers(current_order, powers)
-                and current_order in self.game.get_all_possible_orders()[loc_unit]
+            if current_order != order and not self.is_order_aggressive_to_powers(
+                current_order, powers
             ):
                 return unit + " S " + current_order
 
@@ -695,7 +693,8 @@ class SmartOrderAccepterBot(DipnetBot):
             # fmt: on
 
                 # filter out aggressive orders to allies
-                yield self.replace_aggressive_order_to_allies()
+                if int(self.game.get_current_phase()[1:5]) < 1909:
+                    yield self.replace_aggressive_order_to_allies()
 
             # generate messages for FCT sharing info orders
             opps = list(powers.keys()).copy()


### PR DESCRIPTION
1. filter aggressive move that could happen to allies - (1) this filter applies until 1909 (aggressive in late game should be okay) (2) fix a bug that it keep holding (there is a bug in replacement that replace aggressive orders to support the other unit's move in its power
2. best proposal orders - (1) change rollout length to be 1 movement phase. This is to reduce uncertainty (2) update state value. the prev version is number of supply centers, the current version is len(game.get_centers(power_name)) + 0.5 * len(game.powers[power_name].units) + 0.3*len(game.get_power(power_name).influence)