### PR TITLE
Refactor Dockerfile to reduce container size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Python files
+**/*.egg*
+**/__pycache__/
+
+# Project-specific files
+/docs/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,30 @@
+# This file passes all checks from Hadolint (https://github.com/hadolint/hadolint)
+# Use the command `hadolint Dockerfile` to test
+# Adding Hadolint to `pre-commit` is non-trivial, so the command must be run manually
+
 FROM pcpaquette/tensorflow-serving:20190226 AS base
 
 WORKDIR /model/src/model_server
 
-# install needed packages
-RUN apt-get -y update
-RUN apt-get -y install git
-RUN apt-get -y install vim
-RUN apt-get -y install curl
-RUN apt-get -y install htop
-RUN apt-get -y install lsof
+# Update Git
+# Pinned version is a wildcard because Ubuntu doesn't keep older patch versions available
+RUN apt-get -y update \
+    && apt-get install --no-install-recommends -y 'git=1:2.17.1-1ubuntu0.*' \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy SL model
-RUN wget https://f002.backblazeb2.com/file/ppaquette-public/benchmarks/neurips2019-sl_model.zip
-RUN mkdir /model/src/model_server/bot_neurips2019-sl_model
-RUN unzip neurips2019-sl_model.zip -d /model/src/model_server/bot_neurips2019-sl_model
-RUN chmod -R 777 /model/src/model_server/bot_neurips2019-sl_model
+RUN wget --progress=dot:giga https://f002.backblazeb2.com/file/ppaquette-public/benchmarks/neurips2019-sl_model.zip \
+    && mkdir /model/src/model_server/bot_neurips2019-sl_model \
+    && unzip neurips2019-sl_model.zip -d /model/src/model_server/bot_neurips2019-sl_model \
+    && rm neurips2019-sl_model.zip \
+    && chmod -R 777 /model/src/model_server/bot_neurips2019-sl_model
 
-# Clone repos
-RUN git clone https://github.com/SHADE-AI/diplomacy.git
-RUN git clone https://github.com/SHADE-AI/research.git
+# Clone and prepare research repo
+RUN git config --global --add safe.directory /model/src/model_server/research \
+    && git clone https://github.com/SHADE-AI/research.git \
+    && git --git-dir research/.git/ checkout 78468505b82f37ec298d234ed406d93445cf8281 \
+    && sed -i 's/gym>/gym=/g' research/requirements.txt
 
 # Environment variables
 ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp
@@ -37,26 +43,21 @@ ENV PAD_VARIABLE_LENGTH_INPUTS='true'
 # Test parameter for async tests
 ENV ASYNC_TEST_TIMEOUT=180
 
-# Avoid git issues
-RUN git config --global --add safe.directory /model/src/model_server/diplomacy
-RUN git config --global --add safe.directory /model/src/model_server/research
-
-# Avoid pip issues
-RUN pip install --upgrade pip
+# Later versions of setuptools do not work properly
+RUN pip install --no-cache-dir --upgrade pip==23.0.1 setuptools==66.1.1 wheel==0.38.4
 
 # Install diplomacy research requirements
-WORKDIR /model/src/model_server/research
-RUN sed -i 's/gym>/gym=/g'  requirements.txt
-RUN pip install -r requirements.txt
+# hadolint ignore=DL3059
+RUN pip install --no-cache-dir -r research/requirements.txt
 
 # Install baseline_bots requirements
+# hadolint ignore=DL3059
 RUN mkdir -p /model/src/model_server/baseline_bots/src
 WORKDIR /model/src/model_server/baseline_bots
 COPY README.md pyproject.toml requirements.txt setup.py /model/src/model_server/baseline_bots/
-RUN pip install -r requirements.txt
-RUN pip install -e .
+RUN pip install --no-cache-dir -r requirements.txt -e .
 
-# copy baseline bots code into the docker image
+# Copy baseline_bots code into the Docker image
 COPY src/ /model/src/model_server/baseline_bots/src/
 
 FROM base AS dev
@@ -67,14 +68,14 @@ COPY docs/ /model/src/model_server/baseline_bots/docs/
 COPY scripts/ /model/src/model_server/baseline_bots/scripts/
 COPY tests/ /model/src/model_server/baseline_bots/tests/
 
-# allow the tf server to be run
+# Allow the TF server to be run
 RUN chmod 777 /model/src/model_server/baseline_bots/containers/allan_dip_bot/run_model_server.sh
-# add diplomacy research to python path
+# Add diplomacy research to PYTHONPATH
 ENV PYTHONPATH=/model/src/model_server/research:$PYTHONPATH
 
 FROM dev as test_ci
 
-CMD /bin/bash -c '/model/src/model_server/baseline_bots/containers/allan_dip_bot/run_model_server.sh & pytest'
+CMD ["/bin/bash", "-c", "/model/src/model_server/baseline_bots/containers/allan_dip_bot/run_model_server.sh & pytest"]
 
 FROM base AS allan_dip_bot
 

--- a/containers/allan_dip_bot/BUILD.md
+++ b/containers/allan_dip_bot/BUILD.md
@@ -7,7 +7,8 @@ This is a docker implementation of ALLAN team's bots. The model parameters are e
 Build:
 
 ```shell
-$ docker build --target allan_dip_bot -t allan_dip_bot .
+docker pull allanumd/allan_bots:base-latest
+docker build --target allan_dip_bot --tag allan_dip_bot --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from allanumd/allan_bots:base-latest .
 ```
 
 Usage:


### PR DESCRIPTION
I recently found Hadolint, a tool for linting Dockerfiles, and decided to run it on our existing file. It found many possible ways for it to be improved, which mostly consisted of combining `RUN` statements to save space and pinning versions for reproducibility. I also removed some actions that were unneeded and deleted some files that do not need to be in the final image.

The results are impressive. When building `allan_dip_bot` from `pcpaquette/tensorflow-serving`, the container size went from 4.12 GB to 3.47 GB. In addition, the build time went from 2m33s to 2m7s.

I also modified the build instructions so we can reuse build caches across machines. This will further increase reproducibility and reduce build and transfer times for containers.