### PR TITLE
fixed an error causing FCT to be invalid

### DIFF
--- a/src/baseline_bots/parsing_utils.py
+++ b/src/baseline_bots/parsing_utils.py
@@ -30,6 +30,19 @@ def dipnet_to_daide_parsing(
     :return: DAIDE style order string
     """
 
+    def replace_dipnet_loc(loc: str) -> str:
+        """
+        Replaces dipnet location with DAIDE location
+        E.g. BOT -> GOB
+             ENG -> ECH
+        """
+        if "BOT" in loc:
+            loc = loc.replace("BOT", "GOB")
+        if "ENG" in loc:
+            loc = loc.replace("ENG", "ECH")
+
+        return loc
+
     def expand_prov_coast(prov: str) -> str:
         """
         If `prov` is a coastal province, expand coastal province from dipnet to DAIDE format
@@ -43,6 +56,8 @@ def dipnet_to_daide_parsing(
             prov = prov.replace("/", " ")
             prov = prov + "S"
             prov = "(" + prov + ")"
+        prov = replace_dipnet_loc(prov)
+
         return prov
 
     def daidefy_suborder(dipnet_suborder: str) -> str:
@@ -70,19 +85,7 @@ def dipnet_to_daide_parsing(
         unit_type = "AMY" if dipnet_suborder[0] == "A" else "FLT"
         unit = expand_prov_coast(dipnet_suborder.split()[-1])
 
-        return (
-            "("
-            + (
-                " ".join(
-                    [
-                        power,
-                        unit_type,
-                        unit,
-                    ]
-                )
-            )
-            + ")"
-        )
+        return "(" + (" ".join([power, unit_type, unit,])) + ")"
 
     convoy_map = defaultdict(list)
     dipnet_style_order_strs_tokens = [None for _ in range(len(dipnet_style_order_strs))]


### PR DESCRIPTION
some dipnet tokens have caused game messages to be invalid according to daidepp standards. I added a method in `dipnet_to_daide_parsing` to replace the incorrect tokens with the correct ones.
