### PR TITLE
Fix syntax

### DIFF
--- a/src/baseline_bots/parsing_utils.py
+++ b/src/baseline_bots/parsing_utils.py
@@ -30,6 +30,21 @@ def dipnet_to_daide_parsing(
     :return: DAIDE style order string
     """
 
+    def replace_dipnet_loc(loc: str) -> str:
+        """
+        Replaces dipnet location with DAIDE location
+        E.g. BOT -> GOB
+             ENG -> ECH
+        """
+        if "BOT" in loc:
+            loc = loc.replace("BOT", "GOB")
+        if "ENG" in loc:
+            loc = loc.replace("ENG", "ECH")
+        if "LYO" in loc:
+            loc = loc.replace("LYO", "GOL")
+
+        return loc
+
     def expand_prov_coast(prov: str) -> str:
         """
         If `prov` is a coastal province, expand coastal province from dipnet to DAIDE format
@@ -43,6 +58,8 @@ def dipnet_to_daide_parsing(
             prov = prov.replace("/", " ")
             prov = prov + "S"
             prov = "(" + prov + ")"
+        prov = replace_dipnet_loc(prov)
+
         return prov
 
     def daidefy_suborder(dipnet_suborder: str) -> str:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -66,7 +66,7 @@ class TestUtils:
             ([("A PAR H", "ENG")], ["(ENG AMY PAR) HLD"], True),
             (["A PAR - MAR"], ["(FRA AMY PAR) MTO MAR"], False),
             (["A PAR R MAR"], ["(FRA AMY PAR) MTO MAR"], False),
-            (["F STP/SC - BOT"], ["(RUS FLT (STP SCS)) MTO BOT"], False),
+            (["F STP/SC - BOT"], ["(RUS FLT (STP SCS)) MTO GOB"], False),
             (["A CON - BUL"], ["(TUR AMY CON) MTO BUL"], False),
             (["F BLA - BUL/EC"], ["(TUR FLT BLA) MTO (BUL ECS)"], False),
             (["A BUD S F TRI"], ["(AUS AMY BUD) SUP (AUS FLT TRI)"], False),
@@ -112,9 +112,9 @@ class TestUtils:
                 tc_op,
             )
             comparison_tc_op = (
-                tc_ip[0].replace(" R ", " - ")
+                tc_ip[0].replace(" R ", " - ").replace("BOT", "GOB")
                 if type(tc_ip[0]) == str
-                else tc_ip[0][0].replace(" R ", " - ")
+                else tc_ip[0][0].replace(" R ", " - ").replace("BOT", "GOB")
             )
             assert daide_to_dipnet_parsing(tc_op[0])[0] == comparison_tc_op, (
                 daide_to_dipnet_parsing(tc_op[0]),


### PR DESCRIPTION
some dipnet tokens have caused game messages to be invalid according to daidepp standards. I added a method in `dipnet_to_daide_parsing` to replace the incorrect tokens with the correct ones and changed the corresponding test cases.
