### PR TITLE
Add timed messaging loop

### DIFF
--- a/containers/allan_dip_bot/BUILD.md
+++ b/containers/allan_dip_bot/BUILD.md
@@ -23,6 +23,6 @@ $ docker run -it allan_dip_bot --help
 --outdir    OUT_DIR
 
 #connect to remote game engine
-$ docker run -it allan_dip_bot --game_id test_game --host shade-dev.tacc.utexas.edu --power TURKEY
+$ docker run -it allan_dip_bot --game_id test_game --host shade.tacc.utexas.edu --power TURKEY
 $
 ```

--- a/containers/allan_dip_bot/run_bot.py
+++ b/containers/allan_dip_bot/run_bot.py
@@ -134,6 +134,7 @@ async def play(
             await asyncio.sleep(random.uniform(2, 5))
 
         phase_start_time = time.time()
+        print(f"Starting phase: {current_phase}")
 
         if not game.powers[bot.power_name].is_eliminated():
             # Fetch orders from bot
@@ -141,9 +142,6 @@ async def play(
 
             # Always send orders so engine knows turn is over
             await bot.send_orders(orders_data)
-
-            print(f"Phase: {current_phase}")
-            print(f"Orders: {orders_data}")
 
         phase_end_time = time.time()
         print(
@@ -154,7 +152,7 @@ async def play(
             await asyncio.sleep(2)
 
     t2 = time.perf_counter()
-    print(f"TIMING: {t2-t1:0.4}")
+    print(f"Time taken for game: {t2-t1:0.4}")
     print("-" * 30 + "GAME COMPLETE" + "-" * 30)
 
 

--- a/containers/allan_dip_bot/run_bot.py
+++ b/containers/allan_dip_bot/run_bot.py
@@ -60,6 +60,7 @@ async def play(
     power_name: str,
     bot_class: Type[BaselineBot],
     sleep_delay: bool,
+    communication_stage_length: int,
     discount_factor: float,
     invasion_coef: float,
     conflict_coef: float,
@@ -111,6 +112,7 @@ async def play(
             conflict_support_coef=conflict_support_coef,
             friendly_coef=friendly_coef,
             unrealized_coef=unrealized_coef,
+            communication_stage_length=communication_stage_length,
         )
     else:
         raise ValueError(f"{bot_class.__name__!r} is not a valid bot type")
@@ -195,6 +197,12 @@ def main() -> None:
         help="disable bot sleeping randomly for 1-3s before execution",
     )
     parser.add_argument(
+        "--communication_stage_length",
+        type=int,
+        default=300,  # 5 minutes
+        help="Length of communication stage in seconds",
+    )
+    parser.add_argument(
         "--discount_factor",
         type=float,
         default=0.5,
@@ -249,6 +257,7 @@ def main() -> None:
     power: str = args.power
     bot_type: str = args.bot_type
     sleep_delay: bool = args.no_sleep_delay
+    communication_stage_length: int = args.communication_stage_length
     discount_factor: float = args.discount_factor
     invasion_coef: float = args.invasion_coef
     conflict_coef: float = args.conflict_coef
@@ -270,6 +279,7 @@ def main() -> None:
             power_name=power,
             bot_class=bot_class,
             sleep_delay=sleep_delay,
+            communication_stage_length=communication_stage_length,
             discount_factor=discount_factor,
             invasion_coef=invasion_coef,
             conflict_coef=conflict_coef,

--- a/containers/allan_dip_bot/run_bot.py
+++ b/containers/allan_dip_bot/run_bot.py
@@ -139,9 +139,8 @@ async def play(
             # Fetch orders from bot
             orders_data = await bot()
 
-            # If orders are present, send them
-            if orders_data is not None:
-                await bot.send_orders(orders_data)
+            # Always send orders so engine knows turn is over
+            await bot.send_orders(orders_data)
 
             print(f"Phase: {current_phase}")
             print(f"Orders: {orders_data}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@880416906ef54e5be75549daa56a2f9bc262d8e9
-diplomacy @ git+https://git@github.com/SHADE-AI/diplomacy.git@f561605796c6ddd2c01a9aeb2c6fdabc48a64585
+daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@d55a2090c261783e5128fc7c58b5cb137a7653a6
+diplomacy @ git+https://git@github.com/SHADE-AI/diplomacy.git@ef624e31839de8aaa8b0d62ebd4d394a5178d54e
 gym==0.18.3
 karma_sphinx_theme==0.0.8
 numpy==1.21.6

--- a/scripts/run_games.sh
+++ b/scripts/run_games.sh
@@ -78,7 +78,7 @@ else
   fi
 fi
 
-HOST=shade-dev.tacc.utexas.edu
+HOST=shade.tacc.utexas.edu
 OPTS=(--aggressiveness aggressive)
 
 if [[ -z $GAME_ID ]]; then

--- a/scripts/run_games.sh
+++ b/scripts/run_games.sh
@@ -79,7 +79,7 @@ else
 fi
 
 HOST=shade-dev.tacc.utexas.edu
-OPTS=(--bot_type SmartOrderAccepterBot)
+OPTS=(--aggressiveness aggressive)
 
 if [[ -z $GAME_ID ]]; then
   # Calculate relative path based on script's expected location

--- a/src/baseline_bots/bots/baseline_bot.py
+++ b/src/baseline_bots/bots/baseline_bot.py
@@ -47,7 +47,7 @@ class BaselineBot(ABC):
         while not all(
             power.comm_status == strings.READY
             for power in self.game.powers.values()
-            if power.player_type == strings.PRESS_BOT
+            if power.player_type == strings.PRESS_BOT and not power.is_eliminated()
         ):
             await asyncio.sleep(1)
 

--- a/src/baseline_bots/bots/baseline_bot.py
+++ b/src/baseline_bots/bots/baseline_bot.py
@@ -9,7 +9,12 @@ from diplomacy import Game, Message
 from diplomacy.client.network_game import NetworkGame
 from diplomacy.utils import strings
 
-from baseline_bots.utils import MessagesData, OrdersData, is_valid_daide_message
+from baseline_bots.utils import (
+    LIMITED_MESSAGE_GRAMMAR,
+    MessagesData,
+    OrdersData,
+    is_valid_daide_message,
+)
 
 
 class BaselineBot(ABC):
@@ -87,6 +92,11 @@ class BaselineBot(ABC):
                 f"!! {self.display_name} attempted to send a message with invalid DAIDE syntax: {message!r}"
             )
             return
+
+        if not is_valid_daide_message(message, LIMITED_MESSAGE_GRAMMAR):
+            print(
+                f"!! {self.display_name} sending a message outside of the limited DAIDE syntax: {message!r}"
+            )
 
         msg_obj = Message(
             sender=self.power_name,

--- a/src/baseline_bots/bots/no_press_bot.py
+++ b/src/baseline_bots/bots/no_press_bot.py
@@ -1,7 +1,6 @@
 from typing import ClassVar, List
 
 from diplomacy.utils import strings
-from tornado import gen
 
 from baseline_bots.bots.dipnet_bot import DipnetBot
 
@@ -11,7 +10,6 @@ class NoPressDipBot(DipnetBot):
 
     player_type: ClassVar[str] = strings.NO_PRESS_BOT
 
-    @gen.coroutine
-    def __call__(self) -> List[str]:
-        orders = yield self.gen_orders()
+    async def __call__(self) -> List[str]:
+        orders = await self.gen_orders()
         return orders

--- a/src/baseline_bots/bots/pushover_bot.py
+++ b/src/baseline_bots/bots/pushover_bot.py
@@ -31,7 +31,7 @@ class PushoverDipnet(DipnetBot):
         reply_obj = MessagesData()
 
         orders = yield self.brain.get_orders(self.game, self.power_name)
-        self.orders.add_orders(orders, overwrite=True)
+        self.orders.add_orders(orders)
 
         if len(rcvd_messages) == 0:
             return reply_obj
@@ -51,7 +51,7 @@ class PushoverDipnet(DipnetBot):
             parse_arrangement(last_message.message), self.power_name, self.game
         )
         # set the orders
-        self.orders.add_orders(orders, overwrite=True)
+        self.orders.add_orders(orders)
 
         # set message to say YES
         parsed_message = parse_daide(last_message.message)

--- a/src/baseline_bots/bots/pushover_bot.py
+++ b/src/baseline_bots/bots/pushover_bot.py
@@ -71,5 +71,5 @@ class PushoverDipnet(DipnetBot):
         rcvd_messages = self.read_messages()
         messages = yield self.gen_messages(rcvd_messages)
         yield self.send_messages(messages)
-        orders = self.orders.get_list_of_orders()
+        orders = list(self.orders)
         return orders

--- a/src/baseline_bots/bots/pushover_bot.py
+++ b/src/baseline_bots/bots/pushover_bot.py
@@ -2,7 +2,6 @@ from typing import List
 
 from daidepp import REJ, YES
 from diplomacy import Game, Message
-from tornado import gen
 
 from baseline_bots.bots.dipnet_bot import DipnetBot
 from baseline_bots.utils import (
@@ -25,12 +24,11 @@ class PushoverDipnet(DipnetBot):
     def __init__(self, power_name: str, game: Game, total_msg_rounds=3) -> None:
         super().__init__(power_name, game, total_msg_rounds)
 
-    @gen.coroutine
-    def gen_messages(self, rcvd_messages: List[Message]) -> MessagesData:
+    async def gen_messages(self, rcvd_messages: List[Message]) -> MessagesData:
         self.orders = OrdersData()
         reply_obj = MessagesData()
 
-        orders = yield self.brain.get_orders(self.game, self.power_name)
+        orders = await self.brain.get_orders(self.game, self.power_name)
         self.orders.add_orders(orders)
 
         if len(rcvd_messages) == 0:
@@ -66,10 +64,9 @@ class PushoverDipnet(DipnetBot):
 
         return reply_obj
 
-    @gen.coroutine
-    def __call__(self) -> List[str]:
+    async def __call__(self) -> List[str]:
         rcvd_messages = self.read_messages()
-        messages = yield self.gen_messages(rcvd_messages)
-        yield self.send_messages(messages)
+        messages = await self.gen_messages(rcvd_messages)
+        await self.send_messages(messages)
         orders = list(self.orders)
         return orders

--- a/src/baseline_bots/bots/selectively_transparent_bot.py
+++ b/src/baseline_bots/bots/selectively_transparent_bot.py
@@ -2,7 +2,6 @@ from typing import List
 
 from daidepp import FCT, ORR, XDO
 from diplomacy import Game, Message
-from tornado import gen
 
 from baseline_bots.bots.transparent_bot import TransparentBot
 from baseline_bots.utils import (
@@ -22,11 +21,10 @@ class SelectivelyTransparentBot(TransparentBot):
     def __init__(self, power_name: str, game: Game, total_msg_rounds: int = 3):
         super().__init__(power_name, game, total_msg_rounds)
 
-    @gen.coroutine
     def gen_messages(self, rcvd_messages: List[Message]) -> MessagesData:
         """send out non-aggressive orders that is bot is taking"""
         # call super then find non-aggressive orders
-        messages = yield super().gen_messages(rcvd_messages)
+        messages = super().gen_messages(rcvd_messages)
         for message in messages:
             parsed_message = parse_daide(message["message"])
             if isinstance(parsed_message, FCT):

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -838,7 +838,7 @@ class SmartOrderAccepterBot(DipnetBot):
                 yield self.send_message(foe, str(daide_orders), msgs_data)
 
         except Exception as e:
-            print("Raised Exception in order randomization code block")
+            print(f"Raised {type(e).__name__} in order randomization code block")
             print(e)
             print("Catching the error and resuming operations")
 

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -21,7 +21,6 @@ from daidepp import (
     MoveByCVY,
 )
 from diplomacy import Game
-from diplomacy.client.network_game import NetworkGame
 from stance_vector import ActionBasedStance, ScoreBasedStance
 
 from baseline_bots.bots.dipnet_bot import DipnetBot
@@ -38,7 +37,6 @@ from baseline_bots.utils import (
     OrdersData,
     get_best_orders,
     get_order_tokens,
-    is_valid_daide_message,
     optional_ORR,
     parse_daide,
     smart_select_support_proposals,

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -241,7 +241,7 @@ class SmartOrderAccepterBot(DipnetBot):
         self, best_proposer: str, prp_orders: dict, messages: MessagesData
     ) -> MessagesData:
         """
-        Reply back to allies regarding their proposals whether we follow or not follow
+        Reply to allies regarding their proposals whether we follow or not follow
 
         :param best_proposer: the name of the best proposer as determined by the bot in utils.get_best_orders
         :param prp_orders: dictionary of proposed orders
@@ -391,7 +391,7 @@ class SmartOrderAccepterBot(DipnetBot):
         Determine if selected support order for neighbour corresponds to a self order selected
 
         :param support_order: the support order to be determined for correspondence with self orders
-        :return: boolean indicating the above mentioned detail
+        :return: boolean indicating the detail mentioned above
         """
         order_tokens = get_order_tokens(support_order)
 
@@ -807,7 +807,7 @@ class SmartOrderAccepterBot(DipnetBot):
         # respond to to alliance message and update stance & allies
         yield self.respond_to_alliance_messages(msgs_data)
 
-        # respond to to peace message and update stance & allies
+        # respond to peace message and update stance & allies
         yield self.respond_to_peace_messages(msgs_data)
 
         # generate proposal response YES/NO to allies

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -703,7 +703,7 @@ class SmartOrderAccepterBot(DipnetBot):
         """
         if not self.allies:
             return
-        dipnet_orders = self.orders.get_list_of_orders()
+        dipnet_orders = list(self.orders)
         daide_orders = dipnet_to_daide_parsing(dipnet_orders, self.game)
         final_orders = []
         for order in daide_orders:
@@ -730,7 +730,7 @@ class SmartOrderAccepterBot(DipnetBot):
         msgs_data: MessagesData,
     ) -> OrdersData:
         """Run a single round of messaging."""
-        orders = orders_data.get_list_of_orders()
+        orders = list(orders_data)
 
         rcvd_messages = self.read_messages()
 
@@ -789,7 +789,7 @@ class SmartOrderAccepterBot(DipnetBot):
         orders_data = self.orders
 
         # generate messages for FCT sharing info orders
-        msgs_data = yield self.gen_messages(orders_data.get_list_of_orders(), msgs_data)
+        msgs_data = yield self.gen_messages(list(orders_data), msgs_data)
 
         # send ALY requests at the start of the game
         if self.game.phase == "SPRING 1901 MOVEMENT":
@@ -815,7 +815,7 @@ class SmartOrderAccepterBot(DipnetBot):
             best_proposer, valid_proposal_orders, msgs_data
         )
 
-        dipnet_ords = list(self.orders.orders.values())
+        dipnet_ords = list(self.orders)
         yield self.send_intent_log(f"Using orders {dipnet_ords}")
 
         # randomize dipnet orders and send random orders to enemies
@@ -874,11 +874,13 @@ class SmartOrderAccepterBot(DipnetBot):
         orders = yield from self.brain.get_orders(self.game, self.power_name)
         orders_data = OrdersData()
         orders_data.add_orders(orders)
-        yield self.send_intent_log(f"Initial orders (before communication): {orders}")
+        yield self.send_intent_log(
+            f"Initial orders (before communication): {list(orders_data)}"
+        )
 
         # Skip communications unless in the movement phase
         if not self.game.get_current_phase().endswith("M"):
-            return orders_data.get_list_of_orders()
+            return list(orders_data)
 
         yield self.wait_for_comm_stage()
 
@@ -894,4 +896,4 @@ class SmartOrderAccepterBot(DipnetBot):
                 orders_data, power_stance, msgs_data
             )
 
-        return orders_data.get_list_of_orders()
+        return list(orders_data)

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -842,6 +842,18 @@ class SmartOrderAccepterBot(DipnetBot):
         return orders_data
 
     async def __call__(self) -> List[str]:
+        # get dipnet order
+        orders = await self.brain.get_orders(self.game, self.power_name)
+        orders_data = OrdersData()
+        orders_data.add_orders(orders)
+        await self.send_intent_log(
+            f"Initial orders (before communication): {list(orders_data)}"
+        )
+
+        # Skip communications unless in the movement phase
+        if not self.game.get_current_phase().endswith("M"):
+            return list(orders_data)
+
         # compute pos/neg stance on other bots using Tony's stance vector
 
         # avoid get_stance in the first phase of game
@@ -862,18 +874,6 @@ class SmartOrderAccepterBot(DipnetBot):
             + "}"
         )
         print(f"Stance vector for {self.power_name}: {vector_display}")
-
-        # get dipnet order
-        orders = await self.brain.get_orders(self.game, self.power_name)
-        orders_data = OrdersData()
-        orders_data.add_orders(orders)
-        await self.send_intent_log(
-            f"Initial orders (before communication): {list(orders_data)}"
-        )
-
-        # Skip communications unless in the movement phase
-        if not self.game.get_current_phase().endswith("M"):
-            return list(orders_data)
 
         await self.wait_for_comm_stage()
 

--- a/src/baseline_bots/bots/smart_order_accepter_bot.py
+++ b/src/baseline_bots/bots/smart_order_accepter_bot.py
@@ -759,7 +759,7 @@ class SmartOrderAccepterBot(DipnetBot):
 
         # add orders
 
-        orders_data.add_orders(best_orders, overwrite=True)
+        orders_data.add_orders(best_orders)
         self.orders = orders_data
 
         # Intent message and filter aggressive moves to allies are disabled in S1901M

--- a/src/baseline_bots/bots/transparent_bot.py
+++ b/src/baseline_bots/bots/transparent_bot.py
@@ -2,7 +2,6 @@ from typing import List, Set
 
 from daidepp import FCT, XDO
 from diplomacy import Game, Message
-from tornado import gen
 
 from baseline_bots.bots.dipnet_bot import DipnetBot
 from baseline_bots.parsing_utils import daide_to_dipnet_parsing, dipnet_to_daide_parsing
@@ -46,7 +45,6 @@ class TransparentBot(DipnetBot):
             parsed_orders += parse_arrangement(str(parsed_message.arrangement_qry_not))
         return parsed_orders
 
-    @gen.coroutine
     def gen_messages(self, rcvd_messages: List[Message]) -> MessagesData:
         self.my_orders_informed = False
         comms_obj = MessagesData()
@@ -79,10 +77,9 @@ class TransparentBot(DipnetBot):
 
         return comms_obj
 
-    @gen.coroutine
-    def __call__(self) -> List[str]:
-        self.orders = yield self.gen_orders()
+    async def __call__(self) -> List[str]:
+        self.orders = await self.gen_orders()
         rcvd_messages = self.read_messages()
-        messages = yield from self.gen_messages(rcvd_messages)
-        yield self.send_messages(messages)
+        messages = self.gen_messages(rcvd_messages)
+        await self.send_messages(messages)
         return self.orders

--- a/src/baseline_bots/parsing_utils.py
+++ b/src/baseline_bots/parsing_utils.py
@@ -164,7 +164,7 @@ def dipnet_to_daide_parsing(
                 and dipnet_order_tokens[2] not in unit_game_mapping
             ):
                 raise ValueError(
-                    f"Target unit {dipnet_order_tokens[0]!r} does not have a corresponding power"
+                    f"Target unit {dipnet_order_tokens[2]!r} does not have a corresponding power"
                 )
 
             # Daidefy and add source unit as it is

--- a/src/baseline_bots/parsing_utils.py
+++ b/src/baseline_bots/parsing_utils.py
@@ -8,11 +8,9 @@ from typing import Dict, List, Mapping, Tuple, Union
 
 from daidepp import (
     ALYVSS,
-    AND,
     CVY,
     HLD,
     MTO,
-    ORR,
     PCE,
     PRP,
     SUP,

--- a/src/baseline_bots/parsing_utils.py
+++ b/src/baseline_bots/parsing_utils.py
@@ -2,6 +2,7 @@
 Some quickly built parsing utils mostly for DAIDE stuff
 """
 
+import asyncio
 from collections import defaultdict
 from typing import Dict, List, Mapping, Tuple, Union
 
@@ -224,6 +225,8 @@ def dipnet_to_daide_parsing(
                         "because it has more than 2 tokens"
                     )
                 daide_orders.append(move_order)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             print(
                 f"ALLAN: error from {__name__}.{dipnet_to_daide_parsing.__name__}()\n"
@@ -308,6 +311,8 @@ def daide_to_dipnet_parsing(daide_style_order_str: str) -> Tuple[str, str]:
             )
 
         return dipnet_order, unit_power
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
         print(
             f"ALLAN: error from {__name__}.{daide_to_dipnet_parsing.__name__}\n"
@@ -379,6 +384,8 @@ def parse_proposal_messages(
                             )
                     else:
                         other_orders[order_msg.sender].append(str(order))
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 print(
                     f"ALLAN: error from {__name__}.{parse_proposal_messages.__name__}()\n"
@@ -430,6 +437,8 @@ def parse_proposal_messages(
             "alliance_proposals": alliance_proposals,
             "peace_proposals": peace_proposals,
         }
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
         print(
             f"ALLAN: error from {__name__}.{parse_proposal_messages.__name__}()\n"

--- a/src/baseline_bots/randomize_order.py
+++ b/src/baseline_bots/randomize_order.py
@@ -174,7 +174,7 @@ def orders_correspondence(orders: List) -> List:
     :return: The list of all sets (as tuples) of corresponding orders.
     :rtype: List[Tuple]
     """
-    correspondences = []  # a list of tuples represing all correspondences
+    correspondences = []  # a list of tuples representing all correspondences
     for i, order in enumerate(orders):
         if order[1] == "SUP":
             if len(order) > 3:  # if it is supporting a move

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -18,7 +18,9 @@ from daidepp import (
     PCE,
     AnyDAIDEToken,
     Arrangement,
+    DAIDEGrammar,
     create_daide_grammar,
+    create_grammar_from_press_keywords,
     daide_visitor,
 )
 from daidepp.grammar.grammar import MAX_DAIDE_LEVEL
@@ -42,16 +44,23 @@ POWER_NAMES_DICT = {
 }
 
 MESSAGE_GRAMMAR = create_daide_grammar(level=MAX_DAIDE_LEVEL, string_type="message")
+# Grammar for limited DAIDE subset used in communications protocol
+LIMITED_MESSAGE_GRAMMAR = create_grammar_from_press_keywords(
+    ["ALY_VSS", "AND", "DMZ", "HUH", "NAR", "PCE", "PRP", "REJ", "XDO", "YES"]
+)
 ALL_GRAMMAR = create_daide_grammar(level=MAX_DAIDE_LEVEL, string_type="all")
 
 
-def is_valid_daide_message(string: str) -> bool:
+def is_valid_daide_message(string: str, grammar: Optional[DAIDEGrammar] = None) -> bool:
     """Determines whether a string is a valid DAIDE message.
     :param string: String to check for valid DAIDE.
+    :param grammar: DAIDE grammar to use. Defaults to complete message grammar.
     :return: Whether the string is valid DAIDE or not.
     """
+    if grammar is None:
+        grammar = MESSAGE_GRAMMAR
     try:
-        parse_tree = MESSAGE_GRAMMAR.parse(string)
+        parse_tree = grammar.parse(string)
         daide_visitor.visit(parse_tree)
     except Exception:
         return False

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -21,12 +21,11 @@ from daidepp import (
     create_daide_grammar,
     daide_visitor,
 )
-from daidepp.grammar.grammar import DAIDELevel
+from daidepp.grammar.grammar import MAX_DAIDE_LEVEL
 from diplomacy import Game, Message
 from diplomacy.utils import strings
 import numpy as np
 from tornado import gen
-from typing_extensions import get_args
 
 if TYPE_CHECKING:
     from baseline_bots.bots.dipnet_bot import DipnetBot
@@ -42,7 +41,6 @@ POWER_NAMES_DICT = {
     "TUR": "TURKEY",
 }
 
-MAX_DAIDE_LEVEL = get_args(DAIDELevel)[-1]
 MESSAGE_GRAMMAR = create_daide_grammar(level=MAX_DAIDE_LEVEL, string_type="message")
 ALL_GRAMMAR = create_daide_grammar(level=MAX_DAIDE_LEVEL, string_type="all")
 

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -280,11 +280,8 @@ class OrdersData:
         for order in orders:
             self.add_order(order)
 
-    def get_list_of_orders(self) -> List[str]:
-        return list(self.orders.values())
-
     def __iter__(self):
-        return iter(self.orders)
+        return iter(sorted(self.orders.values()))
 
     def empty(self) -> bool:
         return len(self.orders) > 0

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -4,6 +4,7 @@ It would be preferable to use a real DAIDE parser in prod
 """
 
 
+import asyncio
 from collections import defaultdict
 import collections.abc
 from copy import deepcopy
@@ -61,6 +62,8 @@ def is_valid_daide_message(string: str, grammar: Optional[DAIDEGrammar] = None) 
     try:
         parse_tree = grammar.parse(string)
         daide_visitor.visit(parse_tree)
+    except asyncio.CancelledError:
+        raise
     except Exception:
         return False
     return True
@@ -75,6 +78,8 @@ def parse_daide(string: str) -> AnyDAIDEToken:
     try:
         parse_tree = ALL_GRAMMAR.parse(string)
         return daide_visitor.visit(parse_tree)
+    except asyncio.CancelledError:
+        raise
     except Exception as ex:
         raise ValueError(f"Failed to parse DAIDE string: {string!r}") from ex
 

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -25,7 +25,7 @@ from daidepp import (
     daide_visitor,
 )
 from daidepp.grammar.grammar import MAX_DAIDE_LEVEL
-from diplomacy import Game, Message
+from diplomacy import Game
 from diplomacy.utils import strings
 import numpy as np
 

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -260,28 +260,25 @@ class OrdersData:
     def __init__(self):
         self.orders = defaultdict(str)
 
-    def add_order(self, order: str, overwrite: bool = True) -> None:
+    def add_order(self, order: str) -> None:
         """
         Adds single order
 
-        :param overwrite: whether or not to overwrite an order
+        :param order: order to add
         """
 
         province = get_province_from_order(order)
 
-        if overwrite:
-            self.orders[province] = order
-        elif province not in self.orders:
-            self.orders[province] = order
+        self.orders[province] = order
 
-    def add_orders(self, orders: List[str], overwrite: bool = True) -> None:
+    def add_orders(self, orders: List[str]) -> None:
         """
         Adds multiple orders
 
-        :param overwrite: whether or not to overwrite orders
+        :param orders: orders to add
         """
         for order in orders:
-            self.add_order(order, overwrite)
+            self.add_order(order)
 
     def get_list_of_orders(self) -> List[str]:
         return list(self.orders.values())

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -216,7 +216,7 @@ def is_order_aggressive(order: str, sender: str, game: Game) -> bool:
 
 def get_non_aggressive_orders(orders: List[str], sender: str, game: Game) -> List[str]:
     """
-    :return: all non aggressive orders in orders
+    :return: all non-aggressive orders in orders
     """
     return [order for order in orders if not is_order_aggressive(order, sender, game)]
 

--- a/src/baseline_bots/utils.py
+++ b/src/baseline_bots/utils.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import collections.abc
 from copy import deepcopy
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set, Tuple
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Sequence, Set, Tuple
 
 import daidepp
 from daidepp import (
@@ -257,8 +257,8 @@ class MessagesData(collections.abc.Collection):
 
 
 class OrdersData:
-    def __init__(self):
-        self.orders = defaultdict(str)
+    def __init__(self) -> None:
+        self.orders: Dict[str, str] = defaultdict(str)
 
     def add_order(self, order: str) -> None:
         """
@@ -266,12 +266,10 @@ class OrdersData:
 
         :param order: order to add
         """
-
         province = get_province_from_order(order)
-
         self.orders[province] = order
 
-    def add_orders(self, orders: List[str]) -> None:
+    def add_orders(self, orders: Sequence[str]) -> None:
         """
         Adds multiple orders
 
@@ -280,11 +278,21 @@ class OrdersData:
         for order in orders:
             self.add_order(order)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(sorted(self.orders.values()))
 
-    def empty(self) -> bool:
-        return len(self.orders) > 0
+    def __len__(self) -> int:
+        return len(self.orders)
+
+    def __bool__(self) -> bool:
+        return bool(self.orders)
+
+    def __repr__(self) -> str:
+        contents = dict(sorted(self.orders.items()))
+        return f"{self.__class__.__name__}({contents})"
+
+    def __str__(self) -> str:
+        return str(list(self))
 
 
 @gen.coroutine

--- a/tests/bot_tests/SOA_test.py
+++ b/tests/bot_tests/SOA_test.py
@@ -17,8 +17,6 @@ from baseline_bots.utils import MessagesData, OrdersData, get_order_tokens
 
 SOA_TEST_PARAMS: Final = {
     "num_message_rounds": 3,
-    "min_sleep_time": 1,
-    "max_sleep_time": 3,
 }
 
 

--- a/tests/bot_tests/SOA_test.py
+++ b/tests/bot_tests/SOA_test.py
@@ -295,7 +295,7 @@ class TestSOABot(AsyncTestCase):
             {k: v for k, v in soa_bot_stance.items() if v >= soa_bot.ally_threshold},
         )
         yield soa_bot.replace_aggressive_order_to_allies()
-        print("remove non-aggressive", soa_bot.orders.get_list_of_orders())
+        print("remove non-aggressive", list(soa_bot.orders))
 
         print("finish test ally move filter")
         stop_io_loop()

--- a/tests/bot_tests/SOA_test.py
+++ b/tests/bot_tests/SOA_test.py
@@ -53,7 +53,7 @@ class TestSOABot(AsyncTestCase):
 
     @testing.gen_test
     def test_send_message(self):
-        hostname = "shade-dev.tacc.utexas.edu"
+        hostname = "shade.tacc.utexas.edu"
         port = 8432
         game_id = None
 

--- a/tests/bot_tests/gameplay_framework.py
+++ b/tests/bot_tests/gameplay_framework.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Tuple, Type, Union
 
 from diplomacy import Game
 from diplomacy.utils.export import to_saved_game_format
-from tornado import gen
 
 from baseline_bots.bots.baseline_bot import BaselineBot, BaselineMsgRoundBot
 
@@ -46,13 +45,12 @@ class GamePlay:
         self.cur_local_message_round = 0
         self.phase_init_bots()
 
-    @gen.coroutine
-    def play(self) -> None:
+    async def play(self) -> None:
         """play a game with the bots"""
 
         turn = 0
         while not self.game.is_game_done and turn < self.max_turns:
-            yield self.step()
+            await self.step()
             turn += 1
 
         if self.save_json:
@@ -65,8 +63,7 @@ class GamePlay:
             if isinstance(bot, BaselineMsgRoundBot):
                 bot.phase_init()
 
-    @gen.coroutine
-    def step(self) -> Tuple[Optional[dict], bool]:
+    async def step(self) -> Tuple[Optional[dict], bool]:
         """one step of messaging"""
 
         if self.game.is_game_done:
@@ -86,7 +83,7 @@ class GamePlay:
                 continue
 
             # get orders to be sent from bot
-            orders = yield bot()
+            orders = await bot()
 
         # get/set orders
         for bot in self.bots:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -23,15 +23,12 @@ class TestUtils:
 
         orders_data = OrdersData()
 
-        # test regular add
+        # test initial add
         orders_data.add_order(EXAMPLE_ORDER)
         assert orders_data.get_list_of_orders() == ["A VIE S A BUD - GAL"]
 
-        # test guarded add
-        orders_data.add_order(EXAMPLE_ORDER_2, overwrite=False)
-        assert orders_data.get_list_of_orders() == ["A VIE S A BUD - GAL"]
-
-        orders_data.add_order(EXAMPLE_ORDER_2, overwrite=True)
+        # test overwrite add
+        orders_data.add_order(EXAMPLE_ORDER_2)
         assert orders_data.get_list_of_orders() == ["A VIE H"]
 
     DIPNET_TO_DAIDE_PARSING_TEST_CASES = [

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -25,11 +25,11 @@ class TestUtils:
 
         # test initial add
         orders_data.add_order(EXAMPLE_ORDER)
-        assert orders_data.get_list_of_orders() == ["A VIE S A BUD - GAL"]
+        assert list(orders_data) == ["A VIE S A BUD - GAL"]
 
         # test overwrite add
         orders_data.add_order(EXAMPLE_ORDER_2)
-        assert orders_data.get_list_of_orders() == ["A VIE H"]
+        assert list(orders_data) == ["A VIE H"]
 
     DIPNET_TO_DAIDE_PARSING_TEST_CASES = [
         (["A PAR H"], ["( FRA AMY PAR ) HLD"], False),


### PR DESCRIPTION
This PR changes the SOA bot from using a set number of iterations to looping until a time limit is reached, finishing the `comm_state` conversion started in #189.

It also includes many related and unrelated changes. Most are refactors, but a notable one is a07b2a8e15fb7ad58d42032cee6e124caea239c1, which prevents the bots from stalling once one bot has been eliminated.